### PR TITLE
index.html: hide button's dotted border on Firefox

### DIFF
--- a/index.html
+++ b/index.html
@@ -36,6 +36,9 @@ button[type="submit"]::before {
 button[type="submit"]:disabled::before {
 	content: "";
 }
+button[name="sb"]::-moz-focus-inner{
+	border: none;
+}
 
 @keyframes loading {
   0%    { transform: rotate(0deg); }


### PR DESCRIPTION
On Firefox, the submit button gains a dotted border when it's clicked.
This change allows the button to have no border at all times.

Ref: https://stackoverflow.com/a/199319/266309